### PR TITLE
chore: techbook-template-cli を v0.12 → v0.13 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check": "npx --yes @biomejs/biome check --apply-unsafe ./src"
   },
   "dependencies": {
-    "techbook-template-cli": "github:kght6123/techbook-template-cli#v0.12-Release"
+    "techbook-template-cli": "github:kght6123/techbook-template-cli#v0.13-Release"
   },
   "devDependencies": {
     "@biomejs/biome": "1.5.3"


### PR DESCRIPTION
## Summary

- `techbook-template-cli` の依存バージョンを `v0.12-Release` → `v0.13-Release` に更新

## Test plan

- [ ] `npm run dev` でプレビューが正常に起動するか確認
- [ ] `npm run build` でPDF生成が正常に完了するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)