### PR TITLE
chore: techbook-template-cli を v0.14 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check": "npx --yes @biomejs/biome check --apply-unsafe ./src"
   },
   "dependencies": {
-    "techbook-template-cli": "github:kght6123/techbook-template-cli#v0.12-Release"
+    "techbook-template-cli": "github:kght6123/techbook-template-cli#v0.14-Release"
   },
   "devDependencies": {
     "@biomejs/biome": "1.5.3"


### PR DESCRIPTION
## Summary

- `techbook-template-cli` の依存バージョンを `v0.12-Release` → `v0.14-Release` に更新

## v0.14 の主な変更点

- チャプターカバーに `description1` / `description2` frontmatter フィールドを追加
  - `description1`: H2リスト上部に表示する短いラベル
  - `description2`: H2リスト下部に表示する詳細説明文
  - 未設定時は既存の `description` の `split` 動作にフォールバック（後方互換性あり）

## Test plan

- [ ] `npm run dev` でプレビューが正常に起動すること
- [ ] `description1` / `description2` を設定したチャプターでカバーが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)