### PR TITLE
chore: techbook-template-cli を v0.16 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check": "npx --yes @biomejs/biome check --apply-unsafe ./src"
   },
   "dependencies": {
-    "techbook-template-cli": "github:kght6123/techbook-template-cli#v0.14-Release"
+    "techbook-template-cli": "github:kght6123/techbook-template-cli#v0.16-Release"
   },
   "devDependencies": {
     "@biomejs/biome": "1.5.3"


### PR DESCRIPTION
## 変更内容

`techbook-template-cli` を `v0.15-Release` → `v0.16-Release` に更新します。

## v0.16 の主な変更

- QRコードを複数配置したときのレイアウト崩れを修正（[#4](https://github.com/kght6123/techbook-template-cli/pull/4)）
  - `figcaption` に `word-break` を追加し長いURLの折り返しに対応
  - `figure` に `break-inside: avoid` を追加しPDF生成時の分断を防止
  - `figure` に margin を追加し複数連続配置時の間隔を確保